### PR TITLE
Authentication failed for Keycloack users having special characters in firstName or lastName

### DIFF
--- a/src/main/java/com/quest/keycloak/protocol/wsfed/builders/RequestSecurityTokenResponseBuilder.java
+++ b/src/main/java/com/quest/keycloak/protocol/wsfed/builders/RequestSecurityTokenResponseBuilder.java
@@ -27,6 +27,7 @@ import org.keycloak.dom.saml.v1.assertion.SAML11AssertionType;
 import org.keycloak.dom.saml.v2.assertion.AssertionType;
 import org.keycloak.saml.RandomSecret;
 import org.keycloak.saml.SignatureAlgorithm;
+import org.keycloak.saml.common.constants.GeneralConstants;
 import org.keycloak.saml.common.exceptions.ConfigurationException;
 import org.keycloak.saml.common.exceptions.ProcessingException;
 import org.keycloak.saml.common.util.Base64;
@@ -59,6 +60,7 @@ import javax.xml.datatype.XMLGregorianCalendar;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.security.KeyPair;
 import java.security.PublicKey;
 import java.security.cert.X509Certificate;
@@ -342,7 +344,7 @@ public class RequestSecurityTokenResponseBuilder extends WSFedResponseBuilder {
         RequestSecurityTokenResponseCollection coll = new RequestSecurityTokenResponseCollection();
         coll.addRequestSecurityTokenResponse(response);
         writer.write(coll);
-        return new String(bos.toByteArray());
+        return new String(bos.toByteArray(), Charset.forName(GeneralConstants.SAML_CHARSET_NAME));
     }
 
     /**


### PR DESCRIPTION
The WS-Fed authentication fails for Keycloack users having special characters (french accents in our case) in their firstName or lastName.

The problem is due to different encodings used when XML serializing and java string conversion are made in order to build the 'wresult' parameter of the SAML response.

GeneralConstants.SAML_CHARSET_NAME (which is set by default to UTF-8) is used for XML serialization and platform default encoding (windows-1252 in our case) is used for java string conversion of that XML.

In order to fix it, explicit use of GeneralConstants.SAML_CHARSET_NAME can be done for string conversion.